### PR TITLE
ci: add reusable Rust artifact workflows

### DIFF
--- a/.github/actions/build-artifact/action.yml
+++ b/.github/actions/build-artifact/action.yml
@@ -1,0 +1,92 @@
+name: Build Rust artifact
+description: Build, package, and upload the hpm_isp binary as a workflow artifact.
+
+inputs:
+  binary-name:
+    description: Binary name to package.
+    required: true
+  artifact-version:
+    description: Version string to include in the packaged archive name.
+    required: true
+  target:
+    description: Rust target triple to build.
+    required: true
+  profile:
+    description: Cargo profile to build.
+    required: false
+    default: debug
+  archive:
+    description: Archive format to create.
+    required: false
+    default: tar.gz
+  exe-suffix:
+    description: Executable suffix for the target platform.
+    required: false
+    default: ""
+  artifact-name:
+    description: Workflow artifact name.
+    required: true
+  retention-days:
+    description: Workflow artifact retention period.
+    required: false
+    default: "7"
+  locked:
+    description: Whether to pass --locked to cargo build.
+    required: false
+    default: "true"
+
+runs:
+  using: composite
+  steps:
+    - name: Install Rust target
+      shell: bash
+      run: rustup target add "${{ inputs.target }}"
+
+    - name: Build binary
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        args=(build --target "${{ inputs.target }}" --verbose)
+        if [ "${{ inputs.locked }}" = "true" ]; then
+          args+=(--locked)
+        fi
+        if [ "${{ inputs.profile }}" = "release" ]; then
+          args+=(--release)
+        fi
+
+        cargo "${args[@]}"
+
+    - name: Build archive
+      id: archive
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        staging="${{ inputs.binary-name }}-${{ inputs.artifact-version }}-${{ inputs.target }}"
+        binary="target/${{ inputs.target }}/${{ inputs.profile }}/${{ inputs.binary-name }}${{ inputs.exe-suffix }}"
+
+        mkdir -p "$staging"
+        cp README.md LICENSE 99-hpm_bootrom.rules "$staging/"
+        cp "$binary" "$staging/"
+
+        if [ "${{ inputs.archive }}" = "zip" ]; then
+          asset="$staging.zip"
+          (cd "$staging" && 7z a "../$asset" .)
+        elif [ "${{ inputs.archive }}" = "tar.gz" ]; then
+          asset="$staging.tar.gz"
+          tar czf "$asset" -C "$staging" .
+        else
+          echo "Unsupported archive format: ${{ inputs.archive }}" >&2
+          exit 1
+        fi
+
+        echo "asset=$asset" >> "$GITHUB_OUTPUT"
+
+    - name: Upload workflow artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: ${{ steps.archive.outputs.asset }}
+        if-no-files-found: error
+        retention-days: ${{ inputs.retention-days }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,23 +2,38 @@ name: Build
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
+
+permissions:
+  contents: read
 
 env:
+  BIN_NAME: hpm_isp
   CARGO_TERM_COLOR: always
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v7
       - name: Install dependencies
         run: sudo apt install libusb-1.0-0-dev libudev-dev -y
-      - name: Build
-        run: cargo build --verbose
+      - name: Install Rust components
+        run: rustup component add rustfmt clippy
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Run Clippy
+        run: cargo clippy --workspace --all-targets --all-features -- -D warnings
+      - name: Build and upload artifact
+        uses: ./.github/actions/build-artifact
+        with:
+          binary-name: ${{ env.BIN_NAME }}
+          artifact-version: ${{ github.sha }}
+          target: x86_64-unknown-linux-gnu
+          profile: release
+          artifact-name: build-x86_64-unknown-linux-gnu
       - name: Run tests
         run: cargo test --verbose

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,75 +1,120 @@
-# Reference:
-# https://eugene-babichenko.github.io/blog/2020/05/09/github-actions-cross-platform-auto-releases/
-
 name: Release
+
 on:
   release:
-    types: [ created ]
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: Release tag to build
+        required: true
+        type: string
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
 env:
   BIN_NAME: hpm_isp
+  CARGO_TERM_COLOR: always
+  RELEASE_TAG: ${{ github.event.release.tag_name || inputs.tag }}
+
 jobs:
   build-release:
-    name: build-release
+    name: build-${{ matrix.build }}
+    permissions:
+      contents: read
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
         build: [linux, macos, win-msvc]
         include:
           - build: linux
-            os: ubuntu-latest
+            os: ubuntu-24.04
             rust: stable
             target: x86_64-unknown-linux-gnu
+            exe_suffix: ""
+            archive: tar.gz
           - build: macos
-            os: macos-latest
+            os: macos-15
             rust: stable
-            target: x86_64-apple-darwin
+            target: aarch64-apple-darwin
+            exe_suffix: ""
+            archive: tar.gz
           - build: win-msvc
-            os: windows-2019
+            os: windows-2022
             rust: stable
             target: x86_64-pc-windows-msvc
+            exe_suffix: .exe
+            archive: zip
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v7
         with:
           fetch-depth: 1
+          ref: ${{ env.RELEASE_TAG }}
+
       - name: Install packages (Ubuntu)
-        if: matrix.os == 'ubuntu-latest'
+        if: matrix.os == 'ubuntu-24.04'
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends libusb-1.0-0-dev libudev-dev
+
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: ${{ matrix.rust }}
-          profile: minimal
-          override: true
-          target: ${{ matrix.target }}
-      - name: Build release binary
-        run: cargo build --target ${{ matrix.target }} --verbose --release
-      - name: Build archive
-        shell: bash
         run: |
-          outdir="./target/${{ env.TARGET_DIR }}/release"
-          staging="${{ env.BIN_NAME }}-${{ github.event.release.tag_name }}-${{ matrix.target }}"
-          mkdir -p "$staging"
-          cp {README.md,LICENSE,99-hpm_bootrom.rules} "$staging/"
-          if [ "${{ matrix.os }}" = "windows-2019" ]; then
-            cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}.exe" "$staging/"
-            cd "$staging"
-            7z a "../$staging.zip" .
-            echo "ASSET=$staging.zip" >> $GITHUB_ENV
-          else
-            cp "target/${{ matrix.target }}/release/${{ env.BIN_NAME }}" "$staging/"
-            tar czf "$staging.tar.gz" -C "$staging" .
-            echo "ASSET=$staging.tar.gz" >> $GITHUB_ENV
-          fi
-      - name: Upload release archive
-        uses: actions/upload-release-asset@v1.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          rustup toolchain install ${{ matrix.rust }} --profile minimal
+          rustup default ${{ matrix.rust }}
+
+      - name: Cache Cargo dependencies
+        uses: actions/cache@v6
         with:
-          upload_url: ${{ github.event.release.upload_url }}
-          asset_path: ${{ env.ASSET }}
-          asset_name: ${{ env.ASSET }}
-          asset_content_type: application/octet-stream
+          path: |
+            ~/.cargo/git
+            ~/.cargo/registry
+          key: cargo-${{ runner.os }}-${{ matrix.target }}-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            cargo-${{ runner.os }}-${{ matrix.target }}-
+
+      - name: Build and upload artifact
+        uses: ./.github/actions/build-artifact
+        with:
+          binary-name: ${{ env.BIN_NAME }}
+          artifact-version: ${{ env.RELEASE_TAG }}
+          target: ${{ matrix.target }}
+          profile: release
+          archive: ${{ matrix.archive }}
+          exe-suffix: ${{ matrix.exe_suffix }}
+          artifact-name: release-${{ matrix.target }}
+          retention-days: 7
+
+  publish-release:
+    name: publish-release
+    needs: build-release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+    timeout-minutes: 10
+    steps:
+      - name: Download release artifacts
+        uses: actions/download-artifact@v8
+        with:
+          path: dist
+          pattern: release-*
+          merge-multiple: true
+
+      - name: Generate SHA-256 checksums
+        working-directory: dist
+        run: sha256sum ./* > SHA256SUMS
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ env.RELEASE_TAG }}
+          files: dist/*
+          fail_on_unmatched_files: true
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/hpm_isp/src/hid.rs
+++ b/hpm_isp/src/hid.rs
@@ -107,9 +107,10 @@ impl HpmDevice {
         let api = HidApi::new().unwrap();
         // Connect to device using its VID and PID
         let (device, family) = Family::iter()
-            .find_map(|chip| match api.open(Family::pid(), chip.vid()).ok() {
-                Some(device) => Some((device, chip)),
-                None => None,
+            .find_map(|chip| {
+                api.open(Family::pid(), chip.vid())
+                    .ok()
+                    .map(|device| (device, chip))
             })
             .ok_or("Can't find any HPMicro device")?;
         Ok(Self { device, family })

--- a/hpm_isp/src/isp_command.rs
+++ b/hpm_isp/src/isp_command.rs
@@ -346,7 +346,7 @@ pub trait IspCommand: Interface {
 
         while bytes_left > 0 {
             write_length = cmp::min(max_length, bytes_left);
-            file.read(&mut packet.payload[slice_offset..write_length + slice_offset])?;
+            file.read_exact(&mut packet.payload[slice_offset..write_length + slice_offset])?;
             self.write(&packet, cmp::min(508, (write_length + slice_offset) as u16))?;
             bytes_left -= write_length;
             update_progress(


### PR DESCRIPTION
Summary:
- Split Clippy fixes into a separate signed-off commit.
- Add a reusable composite action for Rust artifact packaging.
- Update CI and release workflows for fmt, Clippy, release assets, and macOS arm64.

Validation:
- actionlint .github/workflows/build.yml .github/workflows/release.yml
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets --all-features -- -D warnings
- cargo test --workspace --all-features