### PR TITLE
docs: expose README on docs.rs

### DIFF
--- a/hpm_isp/Cargo.toml
+++ b/hpm_isp/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 authors = ["tfx2001 <tfx2001@outlook.com>"]
 license = "MIT"
 description = "ISP tool for HPMicro MCUs."
+readme = "../README.md"
 repository = "https://github.com/tfx2001/hpm_isp"
 
 [dependencies]

--- a/hpm_isp/src/lib.rs
+++ b/hpm_isp/src/lib.rs
@@ -1,3 +1,9 @@
+#![doc = include_str!(concat!(
+    env!("CARGO_MANIFEST_DIR"),
+    "/",
+    env!("CARGO_PKG_README")
+))]
+
 pub mod hid;
 pub mod isp_command;
 pub mod memory_config;


### PR DESCRIPTION
Render the package README as crate-level documentation in both the workspace and the published crate archive.

Signed-off-by: tfx2001 <tfx2001@outlook.com>