### PR TITLE
Fix CI failure

### DIFF
--- a/.github/actions/build-artifact/action.yml
+++ b/.github/actions/build-artifact/action.yml
@@ -67,7 +67,7 @@ runs:
         binary="target/${{ inputs.target }}/${{ inputs.profile }}/${{ inputs.binary-name }}${{ inputs.exe-suffix }}"
 
         mkdir -p "$staging"
-        cp README.md LICENSE 99-hpm_bootrom.rules "$staging/"
+        cp README.md LICENSE 70-hpm_bootrom.rules "$staging/"
         cp "$binary" "$staging/"
 
         if [ "${{ inputs.archive }}" = "zip" ]; then

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ cargo install hpm_isp
 ### For Linux users
 
 ```shell
-sudo cp 99-hpm_bootrom.rules /etc/udev/rules.d/
+sudo cp 70-hpm_bootrom.rules /etc/udev/rules.d/
 sudo udevadm control --reload-rules
 ```
 


### PR DESCRIPTION
Commit 14ce1ad3a4dd renamed 99-hpm_bootrom.rules to 70-hpm_bootrom.rules. Update the build-artifact action to copy the correct file to the staging directory.